### PR TITLE
use comma for the concurrency trace separator

### DIFF
--- a/code/parser/common.y
+++ b/code/parser/common.y
@@ -443,6 +443,7 @@ static void yyerror(const char *);
 %type <map>      ListOfNamedTrace
 %type <sequence> IdentifierSlashList
 %type <sequence> TraceDefinitionList
+%type <sequence> TraceDefinitionCommaList
 %type <record>   TraceDefinitionTerm
 %type <record>   TraceDefinition
 %type <record>   SimpleTraceDefinition
@@ -2606,6 +2607,21 @@ TraceDefinitionList
         }
         ;
 
+TraceDefinitionCommaList
+        : TraceDefinitionTerm ',' TraceDefinitionTerm
+        { $$ = new Sequence();
+          $$->ImpAppend(*$1);
+          delete $1;
+          $$->ImpAppend(*$3);
+          delete $3;
+        }
+        | TraceDefinitionCommaList ',' TraceDefinitionTerm
+        { $$ = $1;
+          $$->ImpAppend(*$3);
+          delete $3;
+        }
+        ;
+
 TraceDefinitionTerm
         : TraceDefinition                             // TraceDef
         { $$ = $1;
@@ -2660,6 +2676,12 @@ SimpleTraceDefinition
           delete $2;
         }
         | LEX_NONDET '(' TraceDefinitionList ')'
+        { $$ = new TYPE_AS_TracePermuteExpr();
+          MYPARSER::SetPos2(*$$, @1, @4);
+          $$->SetField(1, *$3);
+          delete $3;
+        }
+        | LEX_NONDET '(' TraceDefinitionCommaList ')'
         { $$ = new TYPE_AS_TracePermuteExpr();
           MYPARSER::SetPos2(*$$, @1, @4);
           $$->SetField(1, *$3);


### PR DESCRIPTION
semicolons are also allowed for backward compatibility.